### PR TITLE
Support xarray-like threshold and add Weibull‘s ensemble conversion

### DIFF
--- a/weatherbenchX/metrics/wrappers.py
+++ b/weatherbenchX/metrics/wrappers.py
@@ -47,7 +47,7 @@ import xarray as xr
 
 def binarize_thresholds(
     x: xr.DataArray,
-    thresholds: Iterable[float],
+    thresholds: Union[Iterable[float], xr.DataArray, xr.Dataset],
     threshold_dim: str,
 ) -> xr.DataArray:
   """Binarizes a continuous array using a threshold value or a list of values.
@@ -57,15 +57,29 @@ def binarize_thresholds(
 
   Args:
     x: Input DataArray.
-    thresholds: List of threshold values.
+    thresholds: List, xarray.DataArray or xarray.Dataset of threshold values.
     threshold_dim: Name of dimension to use for threshold values.
 
   Returns:
     binary_x: Binarized DataArray.
   """
-  threshold = xr.DataArray(
-      thresholds, dims=[threshold_dim], coords={threshold_dim: thresholds}
-  )
+  if isinstance(thresholds, xr.Dataset):
+    assert threshold_dim in thresholds.dims, (
+        f'threshold_dim ({threshold_dim}) not found in thresholds ({thresholds.dims})'
+    )
+    assert x.name in thresholds.data_vars, (
+        f'Input DataArray name ({x.name}) not found in thresholds ({thresholds.data_vars})'
+    )
+    threshold = thresholds[x.name]
+  elif isinstance(thresholds, xr.DataArray):
+    assert threshold_dim in thresholds.dims, (
+        f'threshold_dim ({threshold_dim}) not found in thresholds ({thresholds.dims})'
+    )
+    threshold = thresholds
+  else:
+    threshold = xr.DataArray(
+        thresholds, dims=[threshold_dim], coords={threshold_dim: thresholds}
+    )  
   return (x > threshold).where(~np.isnan(x))
 
 
@@ -128,7 +142,7 @@ class ContinuousToBinary(InputTransform):
   def __init__(
       self,
       which: str,
-      threshold_value: Union[float, Iterable[float]],
+      threshold_value: Union[float, Iterable[float], xr.DataArray],
       threshold_dim: str,
   ):
     """Init.
@@ -136,14 +150,14 @@ class ContinuousToBinary(InputTransform):
     Args:
       which: Which input to apply the wrapper to. Must be one of 'predictions',
         'targets', or 'both'.
-      threshold_value: Threshold value or list of values.
+      threshold_value: Threshold value, list of values or xarray.dataarray.
       threshold_dim: Name of dimension to use for threshold values.
     """
     super().__init__(which)
     # Convert to list if it isn't already.
     self._threshold_value = (
         threshold_value
-        if isinstance(threshold_value, Iterable)
+        if isinstance(threshold_value, (Iterable, xr.DataArray))
         else [threshold_value]
     )
     self._threshold_dim = threshold_dim
@@ -156,6 +170,36 @@ class ContinuousToBinary(InputTransform):
   def transform_fn(self, da: xr.DataArray) -> xr.DataArray:
     return binarize_thresholds(da, self._threshold_value, self._threshold_dim)
 
+
+class WeibullEnsembleToProbabilistic(InputTransform):
+  """
+  Convert ensemble forecasts into probabilitic forecast using the Weibull’s plotting position (Makkonen, 2006).
+  The forecasts should be binarized before applying this wrapper and 
+  you can wrap the metric with the ContinuousToBinary firstly.
+
+  Makkonen, L.: Plotting Positions in Extreme Value Analysis, Journal of Applied Meteorology and Climatology, 
+      45, 334–340, https://doi.org/10.1175/JAM2349.1, 2006.
+"""
+  def __init__(self, which, ensemble_dim='number', skipna=False):
+    """Init.
+
+    Args:
+      which: Which input to apply the wrapper to. Must be 'predictions'.
+      ensemble_dim: Name of ensemble dimension. Default: 'number'.
+    """
+    assert which == 'predictions', 'Only predictions can be converted to probabilities'
+    super().__init__(which)
+    self._ensemble_dim = ensemble_dim
+    self._skipna = skipna
+
+  @property
+  def unique_name_suffix(self) -> str:
+    return 'ensemble_to_probabilistic_by_weibull_plotting_position'
+
+  def transform_fn(self, da: xr.DataArray) -> xr.DataArray:
+    ensemble_members = da.sizes[self._ensemble_dim]
+    return da.sum(self._ensemble_dim, skipna=self._skipna)/(ensemble_members+1)
+  
 
 class Inline(InputTransform):
   """Transform data with a provided function.

--- a/weatherbenchX/metrics/wrappers_test.py
+++ b/weatherbenchX/metrics/wrappers_test.py
@@ -63,6 +63,52 @@ class ContinuousToBinaryTest(parameterized.TestCase):
       expected = x > thresh
       xr.testing.assert_equal(y.sel(threshold=thresh, drop=True), expected)
 
+  def test_datarray_threshold(self):
+    target = test_utils.mock_target_data(random=True)
+    threshold_percentiles = [0.25, 0.75]
+    threshold_dataarray = target.geopotential.quantile(threshold_percentiles, dim='time')
+    threshold_dataarray = threshold_dataarray.rename({"quantile": "threshold"})
+    ctb = wrappers.ContinuousToBinary(
+        which='both', threshold_value=threshold_dataarray, threshold_dim='threshold'
+    )
+
+    x = target.geopotential
+    y = ctb.transform_fn(x)
+    xr.testing.assert_equal(
+        y.threshold,
+        threshold_dataarray.threshold,
+    )
+    for thresh in threshold_percentiles:
+      expected = x > threshold_dataarray.sel(threshold=thresh)
+      xr.testing.assert_equal(
+          y.sel(threshold=thresh),
+          expected,
+      )
+
+  def test_dataset_threshold(self):
+    target = test_utils.mock_target_data(random=True)
+    threshold_percentiles = [0.25, 0.75]
+    threshold_dataset = target.quantile(threshold_percentiles, dim='time')
+    threshold_dataset = threshold_dataset.rename({"quantile": "threshold"})
+
+    ctb = wrappers.ContinuousToBinary(
+        which='both', threshold_value=threshold_dataset, threshold_dim='threshold'
+    )
+
+    for var in ["geopotential", "2m_temperature"]:
+      x = target[var]
+      y = ctb.transform_fn(x)
+      xr.testing.assert_equal(
+          y.threshold,
+          threshold_dataset.threshold,
+      )
+      for thresh in threshold_percentiles:
+        expected = x > threshold_dataset[var].sel(threshold=thresh)
+        xr.testing.assert_equal(
+            y.sel(threshold=thresh),
+            expected,
+        )
+
 
 class EnsembleMeanTest(parameterized.TestCase):
 
@@ -87,6 +133,38 @@ class EnsembleMeanTest(parameterized.TestCase):
     y = em.transform_fn(x)
 
     xr.testing.assert_equal(x.mean('realization', skipna=skipna), y)
+
+
+class WeibullEnsembleToProbabilisticTest(parameterized.TestCase):
+
+  @parameterized.parameters(
+      dict(skipna=True),
+      dict(skipna=False),
+  )
+  def test_mean_over_realization_dim(self, skipna):
+    forecast = test_utils.mock_target_data(random=True, ensemble_size=3)
+
+    # Set one single realization to nan
+    forecast = xr.where(
+        forecast.level == forecast.realization[0],
+        np.nan,
+        forecast,
+    )
+    ctb = wrappers.ContinuousToBinary(
+        which='both', threshold_value=0.5, threshold_dim='threshold'
+    )
+    
+    em = wrappers.WeibullEnsembleToProbabilistic(
+        which='predictions', ensemble_dim='realization'
+    )
+
+    x = forecast.geopotential
+    binary_y = ctb.transform_fn(x)
+    y = em.transform_fn(binary_y)
+    ensemble_members = x.sizes['realization']
+    xr.testing.assert_equal(
+      (x > 0.5).sum('realization', skipna=skipna)/(ensemble_members+1), 
+      y.sel(threshold=0.5, drop=True))
 
 
 class InlineTest(parameterized.TestCase):


### PR DESCRIPTION
Improve the `binarize_thresholds` and `ContinuousToBinary` functions in the `wrappers.py` to support threshold in the forms of  xarray.DataArray and xarray.Dataset. 
Add a new class `WeibullEnsembleToProbabilistic` into the `wrappers.py` for converting ensemble forecasts into probabilistic forecasts using Weibull’s plotting position. 
Add tests in the `wrappers_test.py` to validate these enhancements.