### PR TITLE
FIX: Set xarray deps to >=2024.11.0,<2025.6.0 to prevent casting issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ base_requires = [
     "pandas>=2.2.3",
     "scipy",
     "scikit-learn",
-    "xarray>=2024.11.0",
+    "xarray>=2024.11.0,<2025.6.0",
     "zarr",
     "fsspec",
     "gcsfs",


### PR DESCRIPTION
WB2 and WBX tests fail now after the [Xarray update](https://github.com/pydata/xarray/pull/10406/files). The failures are copy paste below.

```
ValueError: could not safely cast array from int64 to int32. While it is not always the case, a common reason for this is that xarray has deemed it safest to encode np.datetime64[ns] or np.timedelta64[ns] values with int64 values representing units of 'nanoseconds'. This is either due to the fact that the times are known to require nanosecond precision for an accurate round trip, or that the times are unknown prior to writing due to being contained in a chunked array. Ways to work around this are either to use a backend that supports writing int64 values, or to manually specify the encoding['units'] and encoding['dtype'] (e.g. 'seconds since 1970-01-01' and np.dtype('int32')) on the time variable(s) such that the times can be serialized in a netCDF3 file (note that depending on the situation, however, this latter option may result in an inaccurate round trip).
```