### PR TITLE
Select `lead_time` in predictions only

### DIFF
--- a/weatherbenchX/beam_pipeline_test.py
+++ b/weatherbenchX/beam_pipeline_test.py
@@ -142,7 +142,7 @@ class BeamPipelineTest(parameterized.TestCase):
             deterministic.Bias(),
             [
                 wrappers.Select(
-                    which='both',
+                    which='predictions',
                     sel={'lead_time': slice('5D', '10D')},
                 ),
                 wrappers.EnsembleMean(


### PR DESCRIPTION
Previously, this test selected 'lead_time' in 'both'.  This caused a breakage with `Zarr3`, but was a hidden "broken test" in `Zarr2`.

The confusion is that, with Zarr2, pipeline_results turns into all 0's (matching direct_results), whereas in Zarr3, it becomes NaN. To make matters more confusing, the behavior of the bias_5_to_10_days results depends on whether mse and rmse are computed!