### PR TITLE
Update copyright year to 2026 in documentation footer

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@ print("sys.path:", sys.path)
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "WeatherBench-X"
-copyright = "2025, WeatherBench-X authors"
+copyright = "2026, WeatherBench-X authors"
 author = "WeatherBench-X authors"
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
## Summary
Updates the copyright year from 2025 to 2026 in the Sphinx documentation configuration.

## Changes Made
- `docs/source/conf.py`: Updated `copyright` variable from `"2025"` to `"2026"` 

## Type of Change
- [x] Documentation maintenance